### PR TITLE
Allocate Kafka UID/GID from the system service range, not user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,7 @@ class kafka (
   group { $group:
     ensure => present,
     gid    => $group_id,
+    system  => true,
   }
 
   user { $user:
@@ -111,6 +112,7 @@ class kafka (
     shell   => '/bin/bash',
     require => Group[$group],
     uid     => $user_id,
+    system  => true,
   }
 
   file { $package_dir:


### PR DESCRIPTION
Currently when the Kafka user and group are created, they take the UID/GID of the latest human user, +1. This puts it in the 1000+ range, which results in a future clash when we add more human users, since random IDs in the range will be taken.

This change ensures we create them as system users/groups. This uses a different range and avoids future clashes.

Existing systems with existing users will not be impacted.