### PR TITLE
Set explicit EXTRA_ARGS to avoid -loggc being enabled.

### DIFF
--- a/templates/unit.erb
+++ b/templates/unit.erb
@@ -14,6 +14,7 @@ Group=kafka
 SyslogIdentifier=<%= @service_name %>
 <%- case @service_name 
   when 'kafka' -%>
+Environment='EXTRA_ARGS=-name kafkaServer'
 Environment='KAFKA_HEAP_OPTS=<%= @heap_opts %>'
 Environment='KAFKA_LOG4J_OPTS=<%= @log4j_opts %>'
 Environment='KAFKA_JMX_OPTS=<%= @jmx_opts %>'


### PR DESCRIPTION
This option is enabled by default otherwise and results in huge log files being created on the root volume, with nothing of use to us in it. By setting an explicit EXTRA_ARGs, we avoid the `-loggc` enabled version.